### PR TITLE
E11 on q:

### DIFF
--- a/plugin/autoread.vim
+++ b/plugin/autoread.vim
@@ -129,17 +129,17 @@ function! WatchForChanges(bufname, ...)
         "exec "au BufDelete    ".a:bufname . " :echomsg 'Removing autocommands for ".id."' | au! ".id . " | augroup! ".id
         exec "au BufDelete    ".a:bufname . " execute 'au! ".id."' | execute 'augroup! ".id."'"
       end
-        exec "au BufEnter     ".event_bufspec . " :checktime ".bufspec
-        exec "au CursorHold   ".event_bufspec . " :checktime ".bufspec
-        exec "au CursorHoldI  ".event_bufspec . " :checktime ".bufspec
+        exec "au BufEnter     ".event_bufspec . " :silent! checktime ".bufspec
+        exec "au CursorHold   ".event_bufspec . " :silent! checktime ".bufspec
+        exec "au CursorHoldI  ".event_bufspec . " :silent! checktime ".bufspec
 
       " The following events might slow things down so we provide a way to disable them...
       " vim docs warn:
       "   Careful: Don't do anything that the user does
       "   not expect or that is slow.
       if more_events
-        exec "au CursorMoved  ".event_bufspec . " :checktime ".bufspec
-        exec "au CursorMovedI ".event_bufspec . " :checktime ".bufspec
+        exec "au CursorMoved  ".event_bufspec . " :silent! checktime ".bufspec
+        exec "au CursorMovedI ".event_bufspec . " :silent! checktime ".bufspec
       end
     augroup END
     let msg = msg . 'Now watching ' . bufspec . ' for external updates...'


### PR DESCRIPTION
When trying to edit the command line  using `q:` one gets:

```
Error detected while processing CursorMoved Auto commands for "*":
E11: Invalid in command-line window; <CR> executes, CTRL-C quits: :checktime
```

It's trying to invoke `:checktime` anywhere, and at the command line this seems a problem.
